### PR TITLE
ci: check python type annotations on precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,16 @@ repos:
   - id: commitizen
     stages:
     - commit-msg
+
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
   rev: v0.2.2
   hooks:
     # Run the linter.
     - id: ruff
+
+repos:
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.366
+    hooks:
+    - id: pyright


### PR DESCRIPTION
Expected this to be a larger change, requiring touching up types throughout the repo. Turns out types are already sound, so this change simply enables the precommit check.