### PR TITLE
MVP serialization/deserialization

### DIFF
--- a/ml_instrumentation/Writer.py
+++ b/ml_instrumentation/Writer.py
@@ -108,6 +108,11 @@ class Writer:
 
         return res
 
+    def dump(self) -> str:
+        self._con.row_factory = None
+        self.sync_now()
+        return ''.join(self._con.iterdump())
+
     def close(self):
         self.sync_now()
         self._con.close()


### PR DESCRIPTION
This PR ensures MVP serialization/deserialization of the `Collector` object. In memory databases are handled automatically by the library now. On disk databases are assumed to be in the same location when deserializing the pickle---this means the checkpointer needs to be responsible for getting the database in place before deserializing.