### PR TITLE
Frame counting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,7 @@ repos:
     # Run the linter.
     - id: ruff
 
-repos:
-  - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.366
-    hooks:
-    - id: pyright
+- repo: https://github.com/RobertCraigie/pyright-python
+  rev: v1.1.366
+  hooks:
+  - id: pyright

--- a/ml_instrumentation/Collector.py
+++ b/ml_instrumentation/Collector.py
@@ -40,6 +40,7 @@ class Collector:
     # -------------
     def set_experiment_id(self, id: str | int):
         self._exp_id = id
+        self._frame = -1
 
     def get_current_experiment_id(self) -> str | int:
         assert self._exp_id is not None

--- a/ml_instrumentation/Collector.py
+++ b/ml_instrumentation/Collector.py
@@ -69,6 +69,9 @@ class Collector:
         if name in self._ignore:
             return
 
+        if self._frame == -1:
+            self.next_frame()
+
         v = self._sampler.get(name, self._def).next(value)
         if v is None:
             return

--- a/ml_instrumentation/Collector.py
+++ b/ml_instrumentation/Collector.py
@@ -57,7 +57,6 @@ class Collector:
 
             self._write(k, v)
 
-        self.next_frame()
         self._frame = -1
 
     def close(self):

--- a/tests/integration/test_Collector.py
+++ b/tests/integration/test_Collector.py
@@ -23,6 +23,25 @@ def test_collector_rw1(basic_collector):
         SqlPoint(frame=1, id=0, measurement=1),
     ]
 
+def test_collector_rw_trailing_edge1(basic_collector):
+    basic_collector.set_experiment_id(0)
+
+    # note: no next_frame call here, it will go after
+    basic_collector.collect('m1', 0)
+    assert basic_collector.get('m1', 0) == [
+        SqlPoint(frame=0, id=0, measurement=0),
+    ]
+
+    basic_collector.next_frame()
+
+    # next_frame can also go in between collect and get
+    basic_collector.collect('m1', 1)
+    basic_collector.next_frame()
+    assert basic_collector.get('m1', 0) == [
+        SqlPoint(frame=0, id=0, measurement=0),
+        SqlPoint(frame=1, id=0, measurement=1),
+    ]
+
 
 def test_collector_serde(basic_collector):
     basic_collector.set_experiment_id(0)


### PR DESCRIPTION
Currently frame counting is always assumed to be leading edge:
```python
for t in range(timesteps):
  collector.next_frame()
  collector.collect('metric', data)
```
however, this is a bit of a misnomer with the name "next_frame". A better name would have been `start_frame` or something similar.

This PR makes us agnostic to leading edge vs trailing edge frame counting, the following is now equivalent:
```python
for t in range(timesteps):
  collector.collect('metric', data)
  collector.next_frame()
```
Note: cannot mix leading and trailing edge updates.