### PR TITLE
Fix trailing edge frame counting in evaluate

### DIFF
--- a/ml_instrumentation/Collector.py
+++ b/ml_instrumentation/Collector.py
@@ -83,6 +83,9 @@ class Collector:
         if name in self._ignore:
             return
 
+        if self._frame == -1:
+            self.next_frame()
+
         v = self._sampler.get(name, self._def).next_eval(lmbda)
         if v is None:
             return

--- a/ml_instrumentation/utils.py
+++ b/ml_instrumentation/utils.py
@@ -26,11 +26,5 @@ class Pipe(Sampler):
 
         return out
 
-    def repeat(self, v: float, times: int):
-        for _ in range(times):
-            nv = self.next(v)
-            if nv is not None:
-                yield nv
-
     def end(self):
         return None


### PR DESCRIPTION
When modifying the `next_frame()` counter to allow trailing edge counting, forgot to include this functionality in the `evaluate` function.

Naturally this type of bug usually signals the need to refactor, since adding new functionality required replication of code in two places. For now, going to write this off as a one-off thing. Can refer back to this PR as an "I told you so" in a couple of months when this bites again.

---

Loose fit for this PR, but the second commit removes a bunch of dead code from the copy-paste of the prior version of this library. With the new frame-based strategy, there's no longer any value by having a `repeat` method for the Samplers.