### PR TITLE
Performance testing

### DIFF
--- a/.github/workflows/main_benchmark.yml
+++ b/.github/workflows/main_benchmark.yml
@@ -1,7 +1,12 @@
-name: PR Benchmark
+name: Main Benchmark
 on:
-  pull_request:
-    branches: [ main ]
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  deployments: write
 
 jobs:
   benchmark:

--- a/.github/workflows/pr_benchmark.yml
+++ b/.github/workflows/pr_benchmark.yml
@@ -1,0 +1,44 @@
+name: Benchmark
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  benchmark:
+    name: Run pytest-benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+
+      - name: Setup dependencies
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install uv
+          uv pip compile --extra=dev pyproject.toml -o requirements.txt
+          uv pip sync requirements.txt
+
+      - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
+
+      - name: Run benchmark
+        run: pytest --benchmark-only --benchmark-json output.json
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Python Benchmark with pytest-benchmark
+          tool: 'pytest'
+          output-file-path: output.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-threshold: '130%'
+          comment-on-alert: true
+          summary-always: true
+          fail-on-alert: true
+          auto-push: false
+          alert-comment-cc-users: '@andnp'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "ruff",
     "pytest",
     "pytest-cov",
+    "pytest-benchmark",
     "pyright",
     "commitizen",
     "pre-commit",

--- a/tests/performance/test_Collector.py
+++ b/tests/performance/test_Collector.py
@@ -1,0 +1,42 @@
+import pytest
+from tests.fixtures.collector import basic_collector, disk_collector
+
+from ml_instrumentation.Collector import Collector
+
+@pytest.mark.parametrize('collector_fixture', [basic_collector, disk_collector])
+def test_benchmark_write_path1(collector_fixture, request, benchmark):
+    collector: Collector = request.getfixturevalue(collector_fixture.__name__)
+    collector.set_experiment_id(0)
+
+    def _inner():
+        for i in range(1_000):
+            collector.next_frame()
+            collector.collect('m1', i)
+            collector.collect('m2', f'test string {i}')
+
+        # force any in-flight data to be sync'd
+        # normally would close() the collector, but collector
+        # will be reused for this test
+        collector._writer.sync_now()
+
+    benchmark(_inner)
+
+@pytest.mark.parametrize('collector_fixture', [basic_collector, disk_collector])
+def test_benchmark_read1(collector_fixture, request, benchmark):
+    collector: Collector = request.getfixturevalue(collector_fixture.__name__)
+    collector.set_experiment_id(0)
+    for i in range(1_000):
+        collector.next_frame()
+        collector.collect('m1', i)
+        collector.collect('m2', f'test string {i}')
+
+    collector._writer.sync_now()
+
+    def _inner():
+        d = collector.get('m1', 0)
+        assert len(d) == 1_000
+
+        d = collector.get('m2', 0)
+        assert len(d) == 1_000
+
+    benchmark(_inner)


### PR DESCRIPTION
This PR adds MVP performance testing of the two primary usage paths: Collector.write and Collector.read. Note: only the write-path needs to be high-performance and small losses in the read-path are acceptable.

Also adds a simple CI script to track performance for PRs. A later PR will setup the gh-page for performance graphs.