### PR TITLE
ci: push benchmarks into gh-pages

### DIFF
--- a/.github/workflows/main_benchmark.yml
+++ b/.github/workflows/main_benchmark.yml
@@ -41,9 +41,4 @@ jobs:
           tool: 'pytest'
           output-file-path: output.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: '130%'
-          comment-on-alert: true
-          summary-always: true
-          fail-on-alert: true
-          auto-push: false
-          alert-comment-cc-users: '@andnp'
+          auto-push: true


### PR DESCRIPTION
Minor error in last PR that prevented benchmarks from being pushed into gh-pages. This PR fixes that