### PR TITLE
Merge tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ for step in range(exp.max_steps):
   # not all values need to be stored at each frame
   if step % 100 == 0:
     collector.collect('special', 'test value')
+
+# send the results to some shared storage location
+collector.merge('$SCRATCH/project-name/experiment-name.db')
 ```
 
 ## API Documentation
@@ -214,6 +217,21 @@ assert a == [
   (     1,             0,    44),
 ]
 ```
+
+#### `merge(loc: str)`
+Send the collected data to some shared storage location.
+Designed to be run from many parallel processes, merging collected data into a single shared db in one large dump --- reducing the number of metadata touches to HPC filesystems.
+```python
+collector.merge('/some/shared/storage.db')
+
+import sqlite3
+con = sqlite3.connect('/some/shared/storage.db')
+cur = con.cursor()
+
+cur.execute('SELECT * FROM <metric-name>')
+results = cur.fetchall()
+```
+
 
 ### Sampling
 The collection process is controlled through `Sampler` objects specified in the configuration of the collector.

--- a/ml_instrumentation/Collector.py
+++ b/ml_instrumentation/Collector.py
@@ -104,6 +104,9 @@ class Collector:
     def experiment_ids(self):
         return self._idxs
 
+    def merge(self, loc: str):
+        self._writer.merge(loc)
+
     # --------------
     # -- Internal --
     # --------------

--- a/ml_instrumentation/Writer.py
+++ b/ml_instrumentation/Writer.py
@@ -6,6 +6,8 @@ from collections import defaultdict
 from typing import Any, Dict, List, NamedTuple, Set
 from concurrent.futures import ThreadPoolExecutor, Future
 
+import ml_instrumentation._utils.sqlite as sqlu
+
 logger = logging.getLogger('ml-instrumentation')
 
 class Point(NamedTuple):
@@ -156,10 +158,7 @@ class Writer:
             return
 
         cur = self._con.cursor()
-        cur.row_factory = None
-        res = cur.execute("SELECT name FROM sqlite_master")
-        tables = set(r[0] for r in res.fetchall())
-        self._built |= tables
+        self._built |= sqlu.get_tables(cur)
 
     # ---------------------
     # -- utility methods --

--- a/ml_instrumentation/_utils/sqlite.py
+++ b/ml_instrumentation/_utils/sqlite.py
@@ -1,0 +1,7 @@
+from sqlite3 import Cursor
+from typing import Set
+
+def get_tables(cur: Cursor) -> Set[str]:
+    cur.row_factory = None
+    res = cur.execute("SELECT name FROM sqlite_master")
+    return set(r[0] for r in res.fetchall())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ authors = [
 ]
 dependencies = [
     "numpy>=1.26,<=2.0",
+    "filelock~=3.13",
 ]
 requires-python = ">=3.10,<3.13"
 readme = "README.md"

--- a/tests/integration/test_Writer.py
+++ b/tests/integration/test_Writer.py
@@ -1,4 +1,7 @@
-from ml_instrumentation.Writer import Point, SqlPoint
+from functools import partial
+import sqlite3
+from ml_instrumentation.Writer import Point, SqlPoint, Writer
+from multiprocessing.pool import Pool
 
 def test_write1(writer):
     d = Point(
@@ -51,3 +54,73 @@ def test_write2(writer):
 
     points = writer.read_metric('measurement-2')
     assert len(points) == 334
+
+
+def test_merge1(tmp_path):
+    w1 = Writer(
+        db_path=str(tmp_path / 'w1.db'),
+    )
+
+    w2 = Writer(
+        db_path=':memory:',
+    )
+
+    for i in range(10):
+        w1.write(Point(exp_id=0, metric='a', frame=i, data=i))
+        w2.write(Point(exp_id=1, metric='a', frame=i, data=100+i))
+
+    w1.merge(str(tmp_path / 'total.db'))
+    w2.merge(str(tmp_path / 'total.db'))
+
+    con = sqlite3.connect(tmp_path / 'total.db')
+    cur = con.cursor()
+
+    cur.execute('SELECT * FROM a WHERE id=0 ORDER BY frame')
+    res = cur.fetchall()
+    assert len(res) == 10
+    assert [r[2] for r in res] == [i for i in range(10)]
+
+    cur.execute('SELECT * FROM a WHERE id=1 ORDER BY frame')
+    res = cur.fetchall()
+    assert len(res) == 10
+    assert [r[2] for r in res] == [100+i for i in range(10)]
+
+    cur.execute('SELECT * FROM a')
+    res = cur.fetchall()
+    assert len(res) == 20
+
+    w1.close()
+    w2.close()
+
+
+def test_merge_parallel1(tmp_path):
+    pool = Pool(10)
+    pool.map(partial(_test_merge_parallel1, tmp_path=tmp_path), range(20))
+
+    con = sqlite3.connect(tmp_path / 'total.db')
+    cur = con.cursor()
+
+    for i in range(20):
+        cur.execute(f'SELECT * FROM a WHERE id={i} ORDER BY frame')
+        res = cur.fetchall()
+        assert len(res) == 100
+        assert [r[2] for r in res] == [2*j + i for j in range(100)]
+
+        cur.execute(f'SELECT * FROM b where id={i} ORDER BY frame')
+        res = cur.fetchall()
+        assert len(res) == 100
+        assert [r[2] for r in res] == [f'{j} - {i}' for j in range(100)]
+
+    cur.execute('SELECT * FROM a')
+    res = cur.fetchall()
+    assert len(res) == 20 * 100
+
+
+def _test_merge_parallel1(i: int, tmp_path):
+    writer = Writer(db_path=str(tmp_path / f'w{i}.db'))
+
+    for j in range(100):
+        writer.write(Point(exp_id=i, metric='a', frame=j, data=2*j + i))
+        writer.write(Point(exp_id=i, metric='b', frame=j, data=f'{j} - {i}'))
+
+    writer.merge(str(tmp_path / 'total.db'))


### PR DESCRIPTION
This PR adds the ability to merge several collectors into a shared database across several non-communicating parallel processes.

This should be the last piece needed to integrate into a larger HPC experiment pipeline (e.g. https://github.com/andnp/rl-control-template).